### PR TITLE
Fix slot drag bounds after rotation

### DIFF
--- a/card-table.html
+++ b/card-table.html
@@ -868,9 +868,26 @@
                 // For rotated elements, we need to account for the center point offset
                 const centerOffsetX = (boundingWidth - originalWidth) / 2;
                 const centerOffsetY = (boundingHeight - originalHeight) / 2;
-                
-                newLeft = Math.max(-centerOffsetX, Math.min(newLeft, parentWidth - boundingWidth + centerOffsetX));
-                newBottom = Math.max(-centerOffsetY, Math.min(newBottom, parentHeight - boundingHeight + centerOffsetY));
+
+                let minLeft, maxLeft, minBottom, maxBottom;
+                if (centerOffsetX > 0) {
+                    minLeft = -centerOffsetX;
+                    maxLeft = parentWidth - boundingWidth + centerOffsetX;
+                } else {
+                    minLeft = 0;
+                    maxLeft = parentWidth - boundingWidth;
+                }
+
+                if (centerOffsetY > 0) {
+                    minBottom = -centerOffsetY;
+                    maxBottom = parentHeight - boundingHeight + centerOffsetY;
+                } else {
+                    minBottom = 0;
+                    maxBottom = parentHeight - boundingHeight;
+                }
+
+                newLeft = Math.max(minLeft, Math.min(newLeft, maxLeft));
+                newBottom = Math.max(minBottom, Math.min(newBottom, maxBottom));
                 
                 slot.style.left = newLeft + 'px';
                 slot.style.bottom = newBottom + 'px';


### PR DESCRIPTION
## Summary
- handle rotated slot bounding to allow dragging across full card

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a911a8ccc8326b3d3ffca44aa6459