### PR TITLE
Center cards within oversized slots

### DIFF
--- a/card-table.html
+++ b/card-table.html
@@ -1150,46 +1150,34 @@
             const slotCard = slot.closest('.card');
             const slotRect = slot.getBoundingClientRect();
             const tableRect = document.getElementById('table').getBoundingClientRect();
-            
-            // Calculate the slot's position relative to its parent card
-            const slotLeft = parseFloat(slot.style.left) || 0;
-            const slotTop = parseFloat(slot.style.top) || 0;
-            const slotBottom = parseFloat(slot.style.bottom) || 0;
-            
-            // Get parent card position
-            const parentLeft = parseFloat(slotCard.style.left) || 0;
-            const parentTop = parseFloat(slotCard.style.top) || 0;
-            const parentHeight = slotCard.offsetHeight;
-            
-            // Calculate final position for the dragged card
-            let finalX, finalY;
-            
-            if (slot.style.bottom) {
-                // Positioned from bottom
-                finalX = parentLeft + slotLeft;
-                finalY = parentTop + parentHeight - slotBottom - slot.offsetHeight;
-            } else {
-                // Positioned from top
-                finalX = parentLeft + slotLeft;
-                finalY = parentTop + slotTop;
-            }
-            
+
+            const cardWidth = card.offsetWidth;
+            const cardHeight = card.offsetHeight;
+
+            // Calculate the centered position relative to the table
+            const finalX = slotRect.left - tableRect.left + (slotRect.width - cardWidth) / 2;
+            const finalY = slotRect.top - tableRect.top + (slotRect.height - cardHeight) / 2;
+
             // Apply the snap position
             card.style.left = finalX + 'px';
             card.style.top = finalY + 'px';
             card.style.zIndex = parseInt(slotCard.style.zIndex) + 1;
-            
+
             // Rotate the card to match the slot's rotation
             const slotRotation = parseInt(slot.dataset.rotation) || 0;
             card.style.transform = `rotate(${slotRotation}deg)`;
             card.dataset.rotation = slotRotation;
-            
-            // Track the relationship
+
+            // Get parent card position for relationship tracking
+            const parentLeft = parseFloat(slotCard.style.left) || 0;
+            const parentTop = parseFloat(slotCard.style.top) || 0;
+
+            // Track the relationship using centered offsets
             slotRelationships[card.id] = {
                 hostCard: slotCard.id,
                 slot: slot,
-                offsetX: slotLeft,
-                offsetY: slot.style.bottom ? parentHeight - slotBottom - slot.offsetHeight : slotTop,
+                offsetX: finalX - parentLeft,
+                offsetY: finalY - parentTop,
                 rotation: slotRotation
             };
         }


### PR DESCRIPTION
## Summary
- Center cards when snapping into slots so they no longer stick to slot corners
- Track centered offsets for slotted cards to keep alignment while moving host card

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a9b27b5cc83268e269c921af935ef