### PR TITLE
Restrict slot snapping to exact sizes

### DIFF
--- a/card-table.html
+++ b/card-table.html
@@ -811,10 +811,13 @@
             
             slot.appendChild(editBtn);
             slot.appendChild(controls);
-            
+
             // Add drag functionality for slot positioning
             slot.addEventListener('mousedown', startSlotDrag);
-            
+
+            // Create nested slots for smaller sizes
+            updateNestedSlots(slot);
+
             return slot;
         }
 
@@ -912,6 +915,7 @@
             slot.style.width = dimensions.width + 'px';
             slot.style.height = dimensions.height + 'px';
             slot.dataset.slotSize = size;
+            updateNestedSlots(slot);
         }
 
         function getSlotDimensions(size) {
@@ -925,13 +929,49 @@
             return dimensions[size] || dimensions.tiny;
         }
 
+        function updateNestedSlots(slot) {
+            if (!slot) return;
+
+            // Remove existing nested slots
+            slot.querySelectorAll('.nested-slot').forEach(ns => ns.remove());
+
+            const sizeOrder = ['tiny', 'small', 'big', 'huge', 'giant'];
+            const slotSize = slot.dataset.slotSize || 'tiny';
+            const slotIndex = sizeOrder.indexOf(slotSize);
+            let parent = slot;
+
+            for (let i = slotIndex - 1; i >= 0; i--) {
+                const sizeName = sizeOrder[i];
+                const dims = getSlotDimensions(sizeName);
+                const pWidth = parseFloat(parent.style.width) || parent.offsetWidth;
+                const pHeight = parseFloat(parent.style.height) || parent.offsetHeight;
+
+                const nested = document.createElement('div');
+                nested.className = 'card-slot nested-slot';
+                nested.style.width = dims.width + 'px';
+                nested.style.height = dims.height + 'px';
+                nested.style.left = (pWidth - dims.width) / 2 + 'px';
+                nested.style.top = (pHeight - dims.height) / 2 + 'px';
+                nested.dataset.slotSize = sizeName;
+                nested.dataset.maxSize = slot.dataset.maxSize;
+                nested.dataset.rotation = slot.dataset.rotation || '0';
+
+                parent.appendChild(nested);
+                parent = nested;
+            }
+        }
+
         function rotateSlot90(element) {
             const slot = element.closest('.card-slot');
             const currentRotation = parseInt(slot.dataset.rotation) || 0;
             const newRotation = (currentRotation + 90) % 360;
-            
+
             slot.dataset.rotation = newRotation;
             slot.style.transform = `rotate(${newRotation}deg)`;
+            // Ensure nested slots track rotation
+            slot.querySelectorAll('.nested-slot').forEach(child => {
+                child.dataset.rotation = newRotation;
+            });
         }
 
         function finishSlotEdit(element) {
@@ -1068,17 +1108,19 @@
                 slot.classList.remove('highlight');
             });
             
-            const draggedSize = getSizeIndex(draggedCard.dataset.size);
+            const draggedSizeIndex = getSizeIndex(draggedCard.dataset.size);
             const draggedRect = draggedCard.getBoundingClientRect();
-            
+
             // Check all slots on the table
             document.querySelectorAll('.card-slot').forEach(slot => {
                 const slotCard = slot.closest('.card');
                 if (slotCard === draggedCard) return; // Don't snap to own slots
                 if (slotCard.dataset.flipped === 'true') return; // Ignore slots on face-down cards
 
+                const slotSizeIndex = getSizeIndex(slot.dataset.slotSize);
                 const maxSize = parseInt(slot.dataset.maxSize);
-                if (draggedSize > maxSize) return; // Card too big for this slot
+                if (slotSizeIndex > maxSize) return; // Slot too big for host card
+                if (draggedSizeIndex !== slotSizeIndex) return; // Must match slot size exactly
 
                 const slotRect = slot.getBoundingClientRect();
                 if (isOverlapping(draggedRect, slotRect)) {
@@ -1123,19 +1165,21 @@
                 draggedCard.dataset.rotation = '0';
             }
             
-            const draggedSize = getSizeIndex(draggedCard.dataset.size);
+            const draggedSizeIndex = getSizeIndex(draggedCard.dataset.size);
             const draggedRect = draggedCard.getBoundingClientRect();
             let bestSlot = null;
             let bestOverlap = 0;
-            
-            // Find the best overlapping slot
+
+            // Find the best overlapping slot of matching size
             document.querySelectorAll('.card-slot').forEach(slot => {
                 const slotCard = slot.closest('.card');
                 if (slotCard === draggedCard) return; // Don't snap to own slots
                 if (slotCard.dataset.flipped === 'true') return; // Ignore slots on face-down cards
 
+                const slotSizeIndex = getSizeIndex(slot.dataset.slotSize);
                 const maxSize = parseInt(slot.dataset.maxSize);
-                if (draggedSize > maxSize) return; // Card too big for this slot
+                if (slotSizeIndex > maxSize) return; // Slot too big for host card
+                if (draggedSizeIndex !== slotSizeIndex) return; // Must match slot size exactly
 
                 const slotRect = slot.getBoundingClientRect();
                 const overlap = getOverlapArea(draggedRect, slotRect);
@@ -1145,7 +1189,7 @@
                     bestSlot = slot;
                 }
             });
-            
+
             // Snap to the best slot if overlap is significant
             if (bestSlot && bestOverlap > 1000) { // Minimum overlap threshold
                 snapToSlot(draggedCard, bestSlot);
@@ -1156,46 +1200,28 @@
             const slotCard = slot.closest('.card');
             const slotRect = slot.getBoundingClientRect();
             const tableRect = document.getElementById('table').getBoundingClientRect();
-            
-            // Calculate the slot's position relative to its parent card
-            const slotLeft = parseFloat(slot.style.left) || 0;
-            const slotTop = parseFloat(slot.style.top) || 0;
-            const slotBottom = parseFloat(slot.style.bottom) || 0;
-            
-            // Get parent card position
-            const parentLeft = parseFloat(slotCard.style.left) || 0;
-            const parentTop = parseFloat(slotCard.style.top) || 0;
-            const parentHeight = slotCard.offsetHeight;
-            
-            // Calculate final position for the dragged card
-            let finalX, finalY;
-            
-            if (slot.style.bottom) {
-                // Positioned from bottom
-                finalX = parentLeft + slotLeft;
-                finalY = parentTop + parentHeight - slotBottom - slot.offsetHeight;
-            } else {
-                // Positioned from top
-                finalX = parentLeft + slotLeft;
-                finalY = parentTop + slotTop;
-            }
-            
+            const cardRect = slotCard.getBoundingClientRect();
+
+            // Calculate absolute position for the dragged card
+            const finalX = slotRect.left - tableRect.left;
+            const finalY = slotRect.top - tableRect.top;
+
             // Apply the snap position
             card.style.left = finalX + 'px';
             card.style.top = finalY + 'px';
             card.style.zIndex = parseInt(slotCard.style.zIndex) + 1;
-            
+
             // Rotate the card to match the slot's rotation
             const slotRotation = parseInt(slot.dataset.rotation) || 0;
             card.style.transform = `rotate(${slotRotation}deg)`;
             card.dataset.rotation = slotRotation;
-            
-            // Track the relationship
+
+            // Track the relationship relative to host card
             slotRelationships[card.id] = {
                 hostCard: slotCard.id,
                 slot: slot,
-                offsetX: slotLeft,
-                offsetY: slot.style.bottom ? parentHeight - slotBottom - slot.offsetHeight : slotTop,
+                offsetX: finalX - (cardRect.left - tableRect.left),
+                offsetY: finalY - (cardRect.top - tableRect.top),
                 rotation: slotRotation
             };
         }


### PR DESCRIPTION
## Summary
- ensure cards only snap to slots of matching size
- generate centered nested slots for all smaller sizes inside each slot
- compute slot positions via bounding rectangles for accurate snap placement

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a9ee772bc8326bc881a63e061f6f2