### PR TITLE
Fix slot edit menu positioning

### DIFF
--- a/card-table.html
+++ b/card-table.html
@@ -794,7 +794,7 @@
             // Create a unique ID for this slot to avoid conflicts
             const slotId = `slot-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
             slot.id = slotId;
-            
+
             // Create edit controls with size options and rotate
             const controls = document.createElement('div');
             controls.className = 'slot-edit-controls';
@@ -808,9 +808,16 @@
                 <span class="slot-control" onclick="rotateSlot90(this)">↻ 90°</span>
                 <span class="slot-control" onclick="finishSlotEdit(this)">✓</span>
             `;
-            
+
+            // Link controls with slot and place them on the parent card
+            const controlsId = `${slotId}-controls`;
+            controls.id = controlsId;
+            controls.dataset.slotId = slotId;
+            slot.dataset.controlsId = controlsId;
+
             slot.appendChild(editBtn);
-            slot.appendChild(controls);
+            parentCard.appendChild(controls);
+            positionSlotControls(slot);
             
             // Add drag functionality for slot positioning
             slot.addEventListener('mousedown', startSlotDrag);
@@ -885,33 +892,50 @@
 
                 newLeft += adjustX;
                 newBottom += adjustY;
-                
+
                 slot.style.left = newLeft + 'px';
                 slot.style.bottom = newBottom + 'px';
+                positionSlotControls(slot);
             }
-            
+
             function stopSlotDrag() {
                 document.removeEventListener('mousemove', dragSlot);
                 document.removeEventListener('mouseup', stopSlotDrag);
+                positionSlotControls(slot);
             }
-            
+
             document.addEventListener('mousemove', dragSlot);
             document.addEventListener('mouseup', stopSlotDrag);
         }
 
+        function positionSlotControls(slot) {
+            if (!slot) return;
+            const controlsId = slot.dataset.controlsId;
+            if (!controlsId) return;
+            const controls = document.getElementById(controlsId);
+            if (!controls) return;
+            const slotRect = slot.getBoundingClientRect();
+            const cardRect = slot.closest('.card').getBoundingClientRect();
+            const left = (slotRect.left - cardRect.left) / currentZoom;
+            const top = (slotRect.top - cardRect.top) / currentZoom - 40;
+            controls.style.left = left + 'px';
+            controls.style.top = top + 'px';
+        }
+
         function changeSlotSize(element, size) {
-            const slot = element.closest('.card-slot');
             const controls = element.closest('.slot-edit-controls');
-            
+            const slot = document.getElementById(controls.dataset.slotId);
+
             // Update selection UI
             controls.querySelectorAll('.size-option').forEach(opt => opt.classList.remove('selected'));
             element.classList.add('selected');
-            
+
             // Get new dimensions
             const dimensions = getSlotDimensions(size);
             slot.style.width = dimensions.width + 'px';
             slot.style.height = dimensions.height + 'px';
             slot.dataset.slotSize = size;
+            positionSlotControls(slot);
         }
 
         function getSlotDimensions(size) {
@@ -926,47 +950,49 @@
         }
 
         function rotateSlot90(element) {
-            const slot = element.closest('.card-slot');
+            const controls = element.closest('.slot-edit-controls');
+            const slot = document.getElementById(controls.dataset.slotId);
             const currentRotation = parseInt(slot.dataset.rotation) || 0;
             const newRotation = (currentRotation + 90) % 360;
-            
+
             slot.dataset.rotation = newRotation;
             slot.style.transform = `rotate(${newRotation}deg)`;
+            positionSlotControls(slot);
         }
 
         function finishSlotEdit(element) {
             if (!element) return;
-            
-            const slot = element.closest('.card-slot');
+
+            const controls = element.closest('.slot-edit-controls');
+            if (!controls) return;
+            const slot = document.getElementById(controls.dataset.slotId);
             if (!slot) return;
-            
+
             slot.classList.remove('edit-mode');
-            const controls = slot.querySelector('.slot-edit-controls');
-            if (controls) {
-                controls.classList.remove('show');
-            }
+            controls.classList.remove('show');
         }
 
         function toggleSlotEditMode(slot) {
             if (!slot) return;
-            
+
             const isEditMode = slot.classList.contains('edit-mode');
-            
+
             // Exit all slot edit modes first
             document.querySelectorAll('.card-slot.edit-mode').forEach(s => {
                 s.classList.remove('edit-mode');
-                const controls = s.querySelector('.slot-edit-controls');
+                const controls = document.getElementById(s.dataset.controlsId);
                 if (controls) {
                     controls.classList.remove('show');
                 }
             });
-            
+
             if (!isEditMode) {
                 slot.classList.add('edit-mode');
-                const controls = slot.querySelector('.slot-edit-controls');
+                const controls = document.getElementById(slot.dataset.controlsId);
                 if (controls) {
                     controls.classList.add('show');
-                    
+                    positionSlotControls(slot);
+
                     // Update size selection to match current slot
                     const currentSize = slot.dataset.slotSize || 'tiny';
                     controls.querySelectorAll('.size-option').forEach(opt => {
@@ -1229,10 +1255,12 @@
 
         function exitSlotEditMode(element) {
             if (!element) return;
-            
+
             const controls = element.closest('.slot-edit-controls');
             if (controls) {
                 controls.classList.remove('show');
+                const slot = document.getElementById(controls.dataset.slotId);
+                if (slot) slot.classList.remove('edit-mode');
             }
         }
 
@@ -1577,9 +1605,10 @@
         function updateZoom() {
             const table = document.getElementById('table');
             table.style.transform = `scale(${currentZoom})`;
-            
+
             const zoomLevel = document.getElementById('zoomLevel');
             zoomLevel.textContent = `${Math.round(currentZoom * 100)}%`;
+            document.querySelectorAll('.card-slot.edit-mode').forEach(slot => positionSlotControls(slot));
         }
 
         function clearTable() {


### PR DESCRIPTION
## Summary
- Keep slot edit controls fixed to the card by appending them to the card and repositioning when slots move or rotate
- Ensure menu remains upright on zoom and rotation with helper positioning logic

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ab204a2008326ad25994500b9e547