### PR TITLE
Ensure dragged card stays on top

### DIFF
--- a/card-table.html
+++ b/card-table.html
@@ -44,7 +44,6 @@
         }
 
         .card.dragging {
-            z-index: 1000;
             transform: rotate(5deg) scale(1.1);
         }
 
@@ -666,6 +665,16 @@
         let stacks = [];
         let currentZoom = 1.0;
         let slotRelationships = {}; // Track which cards are in which slots
+
+        function bringCardToFront(card) {
+            const cards = document.querySelectorAll('.card');
+            let maxZ = 0;
+            cards.forEach(c => {
+                const z = parseInt(c.style.zIndex) || 0;
+                if (z > maxZ) maxZ = z;
+            });
+            card.style.zIndex = maxZ + 1;
+        }
 
         function addCard(size, points = null, age = null, slots = null) {
             cardCounter++;
@@ -1428,6 +1437,7 @@
                 isDragging = true;
                 draggedCard = card;
                 draggedCard.classList.add('dragging');
+                bringCardToFront(draggedCard);
             }, dragDelay);
 
             function drag(e) {
@@ -1438,6 +1448,7 @@
                     isDragging = true;
                     draggedCard = card;
                     draggedCard.classList.add('dragging');
+                    bringCardToFront(draggedCard);
                 }
                 
                 if (!isDragging || !draggedCard) return;


### PR DESCRIPTION
## Summary
- Dynamically raise a card's z-index when dragging so it remains visible above others
- Remove fixed z-index from `.card.dragging` style

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ab290ba648326a80cbced142efb0a