### PR TITLE
Fix card grid placement to respect actual card sizes

### DIFF
--- a/card-table.html
+++ b/card-table.html
@@ -1475,14 +1475,14 @@
         }
 
         function getSizeUnits(size) {
-          switch (size) {
-            case "small":
-              return { w: 2, h: 1 };
-            case "big":
-              return { w: 2, h: 2 };
-            default:
-              return { w: 1, h: 1 };
-          }
+          const cellW = 90; // base width of a tiny card
+          const cellH = 126; // base height of a tiny card
+          const width = getCardWidth(size);
+          const height = getCardHeight(size);
+          return {
+            w: Math.ceil(width / cellW),
+            h: Math.ceil(height / cellH),
+          };
         }
 
         function createGrid(rows, cols) {


### PR DESCRIPTION
## Summary
- calculate card grid units from actual card pixel dimensions to avoid overlap

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bb0c7b3c48326b7e5fb486410c61c